### PR TITLE
Add comma to aligner-php options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Aligner](https://github.com/adrianlee44/atom-aligner) add-on to support PHP.
 
 ## Supported operators
-`=>`
+`=>`:
 ```php
 array(
     key  => value,
@@ -25,11 +25,17 @@ echo (
     $a   === 3 ? 'three' :
     $a    == 4 ? 'four' : 'other');
 ```
+`,`:
+```php
+define( 'key',  'value' );
+define( 'key2', 'value2' );
+define( 'key3', 'value3' );
+```
 
 ## Installation
 Aligner must be installed along with this package. For more information, please check out [Aligner](https://github.com/adrianlee44/atom-aligner)
 
 ## Changelog
-- 2017-05-13   v1.1.1   Fix config titles.
-- 2017-05-13   v1.1.0   Add support for == and ===. Update documentation.
-- 2015-05-13   v1.0.0   Initial release
+- 2017-05-13     v1.1.1     Fix config titles.
+- 2017-05-13     v1.1.0     Add support for == and ===. Update documentation.
+- 2015-05-13     v1.0.0     Initial release

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -6,58 +6,77 @@ module.exports = {
       title: 'Padding for =>',
       description: 'Pad left or right of the character',
       type: 'string',
-      "enum": ['left', 'right'],
-      "default": 'left'
+      enum: ['left', 'right'],
+      default: 'left'
     },
     '=>-leftSpace': {
       title: 'Left space for =>',
       description: 'Add 1 whitespace to the left',
       type: 'boolean',
-      "default": true
+      default: true
     },
     '=>-rightSpace': {
       title: 'Right space for =>',
       description: 'Add 1 whitespace to the right',
       type: 'boolean',
-      "default": true
+      default: true
     },
     '=-alignment': {
       title: 'Padding for =',
       description: 'Pad left or right of the character',
       type: 'string',
-      "enum": ['left', 'right'],
-      "default": 'left'
+      enum: ['left', 'right'],
+      default: 'left'
     },
     '=-leftSpace': {
       title: 'Left space for =',
       description: 'Add 1 whitespace to the left',
       type: 'boolean',
-      "default": true
+      default: true
     },
     '=-rightSpace': {
       title: 'Right space for =',
       description: 'Add 1 whitespace to the right',
       type: 'boolean',
-      "default": true
+      default: true
     },
     '==-alignment': {
       title: 'Padding for == (including ===)',
       description: 'Pad left or right of the character',
       type: 'string',
-      "enum": ['left', 'right'],
-      "default": 'left'
+      enum: ['left', 'right'],
+      default: 'left'
     },
     '==-leftSpace': {
       title: 'Left space for == (including ===)',
       description: 'Add 1 whitespace to the left',
       type: 'boolean',
-      "default": true
+      default: true
     },
     '==-rightSpace': {
       title: 'Right space for == (including ===)',
       description: 'Add 1 whitespace to the right',
       type: 'boolean',
-      "default": true
+      default: true
+    },
+    ',-alignment': {
+      title: 'Padding for ,',
+      description: 'Pad left or right of the character',
+      type: 'string',
+      default: 'right',
+      'enum': ['left', 'right']
+    },
+    ',-leftSpace': {
+      title: 'Left space for ,',
+      description: 'Add 1 whitespace to the left of the character',
+      type: 'boolean',
+      default: false
+    },
+    ',-rightSpace': {
+      title: 'Right space for ,',
+      description: 'Add 1 whitespace to the right of the character',
+      type: 'boolean',
+      default: true
     }
   },
   privateConfig: {


### PR DESCRIPTION
Not sure how widely used this would be, but I found it handy for code like this:
```php
define( 'AUTH_KEY',         env( 'AUTH_KEY' ) );
define( 'SECURE_AUTH_KEY',  env( 'SECURE_AUTH_KEY' ) );
define( 'LOGGED_IN_KEY',    env( 'LOGGED_IN_KEY' ) );
define( 'NONCE_KEY',        env( 'NONCE_KEY' ) );
define( 'AUTH_SALT',        env( 'AUTH_SALT' ) );
define( 'SECURE_AUTH_SALT', env( 'SECURE_AUTH_SALT' ) );
define( 'LOGGED_IN_SALT',   env( 'LOGGED_IN_SALT' ) );
define( 'NONCE_SALT',       env( 'NONCE_SALT' ) );
```

Few other minor tidy changes.